### PR TITLE
Update Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-astropy~=4.2.1
+astropy>=4.2.1
 Flask-SQLAlchemy~=2.5.1
+MarkupSafe==0.23 # Flask-SQLAlchemy~=2.5.1 -> Flask>=0.10 -> Jinja2>=2.4 -> MarkupSafe>=0.23, but >0.23 is incompatible
 SQLAlchemy~=1.4.22
 psycopg2-binary~=2.8.6
 requests~=2.25.1


### PR DESCRIPTION
This allows Astropy v5. I think this is pretty safe, because this package only uses `Time` and `SkyCoord`, which are unlikely to change.

It also fixes MarkupSafe to v0.23 to avoid a gigantic mess of dependency conflicts (see https://github.com/pallets/markupsafe/issues/282).